### PR TITLE
feat: connect service forms to Supabase and fix bento layout

### DIFF
--- a/app/seller-app/(dashboard)/page.tsx
+++ b/app/seller-app/(dashboard)/page.tsx
@@ -162,27 +162,31 @@ export default function SewerCenterPage() {
         const first_name = nameParts[0] || "";
         const last_name = nameParts.slice(1).join(" ");
 
-        await supabase.from('users').update({ first_name, last_name }).eq('id', user.id);
+        const { error: userError } = await supabase.from('users').update({ first_name, last_name }).eq('id', user.id);
+        if (userError) throw userError;
         
         if (formData.phone) {
-            await supabase.from('user_phones').upsert({ user_id: user.id, phone: formData.phone }, { onConflict: 'user_id' });
+            const { error: phoneError } = await supabase.from('user_phones').upsert({ user_id: user.id, phone: formData.phone }, { onConflict: 'user_id' });
+            if (phoneError) throw phoneError;
         }
 
         if (formData.social_link) {
-            await supabase.from('user_socials').upsert({ 
+            const { error: socialError } = await supabase.from('user_socials').upsert({ 
                 user_id: user.id, 
                 platform: 'Other', 
                 handle: formData.social_link 
             }, { onConflict: 'user_id, platform' });
+            if (socialError) throw socialError;
         }
 
         // Achievements (Simple replacement logic)
         const achievements = [formData.achievement_1, formData.achievement_2, formData.achievement_3].filter(Boolean);
         if (achievements.length > 0) {
             await supabase.from('sewer_achievements').delete().eq('user_id', user.id);
-            await supabase.from('sewer_achievements').insert(
+            const { error: achError } = await supabase.from('sewer_achievements').insert(
                 achievements.map(title => ({ user_id: user.id, title }))
             );
+            if (achError) throw achError;
         }
 
         const { data: shopAddr } = await supabase
@@ -218,9 +222,10 @@ export default function SewerCenterPage() {
         }
 
         if (shopAddr) {
-            await supabase.from('user_addresses').update(addressData).eq('id', shopAddr.id);
+            const { error: addrError } = await supabase.from('user_addresses').update(addressData).eq('id', shopAddr.id);
+            if (addrError) throw addrError;
         } else {
-            await supabase.from('user_addresses').insert({
+            const { error: addrError } = await supabase.from('user_addresses').insert({
                 user_id: user.id,
                 ...addressData,
                 address_type: 'shop',
@@ -229,14 +234,17 @@ export default function SewerCenterPage() {
                 barangay: addressData.barangay || "",
                 province: addressData.province || "",
             });
+            if (addrError) throw addrError;
         }
 
-        await supabase.from('sewer_settings').upsert({
+        const { error: settingsError } = await supabase.from('sewer_settings').upsert({
             user_id: user.id,
             accepting_alterations: services.alterations,
             accepting_repairs: services.repair,
             accepting_commissions: services.commissions
         }, { onConflict: 'user_id' });
+        
+        if (settingsError) throw settingsError;
 
         setIsEditing(false);
     } catch (error: any) {

--- a/app/sewers/[sewerId]/[service]/page.tsx
+++ b/app/sewers/[sewerId]/[service]/page.tsx
@@ -1,24 +1,44 @@
 import { notFound } from "next/navigation";
-import { getSewerById } from "@/data/sewers";
+import { createClient } from "@/utils/supabase/server";
 import CommissionForm from "@/components/service/commission-form";
 import Image from "next/image";
 import SeparatorX from "@/components/ui/separator-x";
 import ProcessSteps from "@/components/service/process-steps";
 
 interface ServicePageProps {
-  params: {
+  params: Promise<{
     sewerId: string;
     service: string;
-  };
+  }>;
 }
 
 export default async function ServicePage({ params }: ServicePageProps) {
   const { sewerId, service } = await params;
-  const sewer = getSewerById(sewerId);
+  
+  const supabase = await createClient();
+  const { data: user, error } = await supabase
+    .from("users")
+    .select(`
+      id,
+      first_name,
+      last_name,
+      user_type,
+      user_avatars (avatar_url),
+      sewer_settings (accepting_alterations, accepting_repairs, accepting_commissions)
+    `)
+    .eq("id", sewerId)
+    .single();
 
-  if (!sewer) {
+  if (error || !user || user.user_type !== "seller") {
     notFound();
   }
+
+  const settingsArray = Array.isArray(user.sewer_settings) ? user.sewer_settings : [user.sewer_settings].filter(Boolean);
+  const settings = settingsArray[0];
+  const servicesOffered: ("repair" | "alteration" | "commission")[] = [];
+  if (settings?.accepting_repairs) servicesOffered.push("repair");
+  if (settings?.accepting_alterations) servicesOffered.push("alteration");
+  if (settings?.accepting_commissions) servicesOffered.push("commission");
 
   const normalizedService = service.toLowerCase();
   const serviceMap: { [key: string]: string } = {
@@ -31,10 +51,13 @@ export default async function ServicePage({ params }: ServicePageProps) {
 
   if (
     !serviceType ||
-    !sewer.servicesOffered.includes(normalizedService as any)
+    !servicesOffered.includes(normalizedService as any)
   ) {
     notFound();
   }
+  
+  const name = `${user.first_name || ""} ${user.last_name || ""}`.trim() || "Anonymous Sewer";
+  const avatar = user.user_avatars?.[0]?.avatar_url || "/assets/sewer-photos/1.jpg";
 
   const renderServiceContent = () => {
     switch (normalizedService) {
@@ -98,7 +121,7 @@ export default async function ServicePage({ params }: ServicePageProps) {
               </p>
             </div>
             <SeparatorX />
-            <CommissionForm sewerName={sewer.name} sewerImage={sewer.image} />
+            <CommissionForm sewerName={name} sewerImage={avatar} sewerId={sewerId} serviceType="commission" />
             <ProcessSteps steps={commissionSteps} />
           </div>
         );
@@ -157,8 +180,10 @@ export default async function ServicePage({ params }: ServicePageProps) {
             </div>
             <SeparatorX />
             <CommissionForm
-              sewerName={sewer.name}
-              sewerImage={sewer.image}
+              sewerName={name}
+              sewerImage={avatar}
+              sewerId={sewerId}
+              serviceType="repair"
               disableFabric={true}
               disableMeasurements={true}
               orderDetailsLabel="Repair Details"
@@ -220,7 +245,7 @@ export default async function ServicePage({ params }: ServicePageProps) {
               </p>
             </div>
             <SeparatorX />
-            <CommissionForm sewerName={sewer.name} sewerImage={sewer.image} />
+            <CommissionForm sewerName={name} sewerImage={avatar} sewerId={sewerId} serviceType="alteration" />
             <ProcessSteps steps={alterationSteps} />
           </div>
         );

--- a/app/sewers/[sewerId]/page.tsx
+++ b/app/sewers/[sewerId]/page.tsx
@@ -76,7 +76,8 @@ export default async function SewerPage({ params }: PageProps) {
   const achievements = user.sewer_achievements?.map((a: any) => a.title) || [];
   const tesdaCertified = achievements.some(a => a.toLowerCase().includes("tesda"));
 
-  const settings = user.sewer_settings?.[0];
+  const settingsArray = Array.isArray(user.sewer_settings) ? user.sewer_settings : [user.sewer_settings].filter(Boolean);
+  const settings = settingsArray[0];
   const servicesOffered: ("repair" | "alteration" | "commission")[] = [];
   if (settings?.accepting_repairs) servicesOffered.push("repair");
   if (settings?.accepting_alterations) servicesOffered.push("alteration");

--- a/components/service/commission-form.tsx
+++ b/components/service/commission-form.tsx
@@ -3,10 +3,15 @@
 import { useState } from "react";
 import Image from "next/image";
 import PrimaryButton from "../ui/primary-button";
+import { createClient } from "@/utils/supabase/client";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
 
 interface CommissionFormProps {
   sewerName: string;
   sewerImage: string;
+  sewerId: string;
+  serviceType: "commission" | "repair" | "alteration";
   disableEmail?: boolean;
   disableFullName?: boolean;
   disableFabric?: boolean;
@@ -19,6 +24,8 @@ interface CommissionFormProps {
 export default function CommissionForm({
   sewerName,
   sewerImage,
+  sewerId,
+  serviceType,
   disableEmail = false,
   disableFullName = false,
   disableFabric = false,
@@ -27,6 +34,11 @@ export default function CommissionForm({
   disableScheduleAppointment = false,
   orderDetailsLabel = "Order Details",
 }: CommissionFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+  const supabase = createClient();
+
   const [formData, setFormData] = useState({
     email: "",
     fullName: "",
@@ -80,6 +92,52 @@ export default function CommissionForm({
     }
   };
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setErrorMsg("");
+
+    try {
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      
+      if (authError || !user) {
+        throw new Error("You must be logged in to submit a request.");
+      }
+
+      // Format details
+      let finalDetails = formData.orderDetails;
+      if (formData.fabricToUse) {
+        finalDetails += `\nFabric: ${formData.fabricToUse}`;
+      }
+      if (formData.measurements) {
+        finalDetails += `\nMeasurements: ${formData.measurements}`;
+      }
+
+      const { error: submitError } = await supabase.from("service_requests").insert({
+        client_id: user.id,
+        sewer_id: sewerId,
+        service_type: serviceType,
+        contact_email: formData.email || user.email || "",
+        contact_phone: "Not provided", // Add to form later if needed
+        contact_name: formData.fullName || user.user_metadata?.full_name || "User",
+        request_details: finalDetails,
+        appointment_date: formData.scheduleAppointment === "yes" && formData.appointmentDate 
+          ? new Date(formData.appointmentDate).toISOString()
+          : new Date().toISOString(), // Fallback if no date
+        status: "pending"
+      });
+
+      if (submitError) throw submitError;
+      
+      setSuccess(true);
+    } catch (err: any) {
+      console.error("Submission error:", err);
+      setErrorMsg(err.message || "An error occurred while submitting your request.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   const fabricOptions = [
     "Cotton",
     "Linen",
@@ -99,7 +157,26 @@ export default function CommissionForm({
         <span className="text-black">Commision</span> {sewerName}
       </h2>
 
-      <form className="space-y-5">
+      {success ? (
+        <div className="text-center space-y-6">
+          <div className="w-24 h-24 bg-green-100 text-green-500 rounded-full flex items-center justify-center mx-auto mb-6">
+            <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h3 className="text-3xl font-medium text-heading">Request Submitted!</h3>
+          <p className="text-xl text-gray-600">The sewer will review your request and get back to you shortly.</p>
+          <Link href={`/sewers/${sewerId}`}>
+            <PrimaryButton className="mt-8">Return to Profile</PrimaryButton>
+          </Link>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {errorMsg && (
+            <div className="p-4 bg-red-50 text-red-500 rounded-md">
+              {errorMsg}
+            </div>
+          )}
         {!disableEmail && (
           <div>
             <label
@@ -231,12 +308,16 @@ export default function CommissionForm({
           </div>
         )}
 
-        <PrimaryButton type="submit">Confirm Order</PrimaryButton>
+        <PrimaryButton type="submit" disabled={isSubmitting} className="flex items-center justify-center gap-2">
+          {isSubmitting && <Loader2 className="w-5 h-5 animate-spin" />}
+          {isSubmitting ? "Submitting..." : "Confirm Order"}
+        </PrimaryButton>
 
         <p className="text-xs text-center text-[#2C2463] mt-4">
           By continuing, you agree to our terms and conditions
         </p>
       </form>
+      )}
     </div>
   );
 }

--- a/components/sewer-profile/services.tsx
+++ b/components/sewer-profile/services.tsx
@@ -47,7 +47,7 @@ export default function Services({ sewerId, servicesOffered }: ServicesProps) {
 
   return (
     <>
-      <CardBentoGrid items={filteredItems} header="browse" />
+      <CardBentoGrid items={filteredItems} header="Pick a service" />
     </>
   );
 }

--- a/components/ui/service-card.tsx
+++ b/components/ui/service-card.tsx
@@ -18,7 +18,7 @@ export default function ServiceCard({
   return (
     <Link
       href={href}
-      className={`relative block w-full h-100 ${className} col-span-${colSpan}`}
+      className={`relative block w-full h-100 ${className} ${colSpan === 2 ? "md:col-span-2 col-span-1" : "col-span-1"}`}
     >
       <Image
         src={imgSrc}


### PR DESCRIPTION
- Fix Tailwind layout issue in ServiceCard for full-width grid spanning.

- Add error handling for Supabase upserts in Seller Dashboard to prevent silent failures.

- Update Sewer Profile to correctly handle one-to-one 'sewer_settings' relationships.

- Connect CommissionForm (and Repair/Alteration) to the 'service_requests' Supabase table.

- Implement loading states and a success confirmation view upon form submission.
