### PR TITLE
Feat: Update chat behavior to match native messaging apps

### DIFF
--- a/components/messaging/chat-message.tsx
+++ b/components/messaging/chat-message.tsx
@@ -6,22 +6,66 @@ interface ChatMessageItemProps {
   isOwnMessage: boolean
   showHeader?: boolean
   variant?: "default" | "compact"
+  isLatest?: boolean
 }
 
-export const ChatMessageItem = ({ message, isOwnMessage, variant = "default" }: ChatMessageItemProps) => {
+export const ChatMessageItem = ({ message, isOwnMessage, variant = "default", isLatest = false }: ChatMessageItemProps) => {
   const isCompact = variant === "compact";
   
+  const timeString = message.createdAt 
+    ? new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : '';
+
   return (
-    <div className={`flex w-full ${isOwnMessage ? 'justify-end' : 'justify-start'} ${isCompact ? 'mb-2' : 'mb-4'}`}>
-      <div
-        className={cn(
-          'max-w-[80%] shadow-sm text-white font-medium',
-          isCompact ? 'px-4 py-2 rounded-2xl text-sm bg-primary' : 'px-8 py-4 rounded-3xl text-lg third-gradient',
-          isOwnMessage ? (isCompact ? 'rounded-tr-none' : 'rounded-tr-none') : (isCompact ? 'rounded-tl-none' : 'rounded-tl-none')
+    <div 
+      className={`flex w-full flex-col ${isOwnMessage ? 'items-end' : 'items-start'} ${isCompact ? 'mb-2' : 'mb-4'} group focus:outline-none`} 
+      tabIndex={0}
+    >
+      <div className="relative flex max-w-[80%] items-center group/tooltip">
+        {/* Tooltip for own message (appears on the left) */}
+        {isOwnMessage && timeString && !isLatest && (
+          <div className="absolute right-full mr-2 pointer-events-none opacity-0 group-hover/tooltip:opacity-100 transition-opacity group-hover/tooltip:delay-1000 duration-200 bg-gray-800/80 text-white text-[11px] px-2 py-1 rounded-lg whitespace-nowrap z-10">
+            {timeString}
+          </div>
         )}
-      >
-        {message.content}
+
+        <div
+          className={cn(
+            'shadow-sm text-white font-medium transition-transform active:scale-[0.98] w-full',
+            isCompact ? 'px-4 py-2 rounded-2xl text-sm bg-primary' : 'px-8 py-4 rounded-3xl text-lg third-gradient',
+            isOwnMessage ? (isCompact ? 'rounded-tr-none' : 'rounded-tr-none') : (isCompact ? 'rounded-tl-none' : 'rounded-tl-none')
+          )}
+        >
+          {message.content}
+        </div>
+
+        {/* Tooltip for other message (appears on the right) */}
+        {!isOwnMessage && timeString && !isLatest && (
+          <div className="absolute left-full ml-2 pointer-events-none opacity-0 group-hover/tooltip:opacity-100 transition-opacity group-hover/tooltip:delay-1000 duration-200 bg-gray-800/80 text-white text-[11px] px-2 py-1 rounded-lg whitespace-nowrap z-10">
+            {timeString}
+          </div>
+        )}
       </div>
+
+      {timeString && (
+        <div 
+          className={cn(
+            "grid transition-all duration-300 ease-in-out",
+            isLatest 
+              ? "grid-rows-[1fr] opacity-100 mt-1" 
+              : "grid-rows-[0fr] opacity-0 group-focus:grid-rows-[1fr] group-focus:opacity-100 group-focus:mt-1"
+          )}
+        >
+          <div className="overflow-hidden">
+            <span className={cn(
+              "block text-[11px] text-gray-400 px-1",
+              isOwnMessage ? "mr-1 text-right" : "ml-1 text-left"
+            )}>
+              {timeString}
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/messaging/realtime-chat.tsx
+++ b/components/messaging/realtime-chat.tsx
@@ -100,12 +100,13 @@ export const RealtimeChat = ({
           </div>
         ) : null}
         
-        {allMessages.map((message) => (
+        {allMessages.map((message, index) => (
           <ChatMessageItem
             key={message.id}
             message={message}
             isOwnMessage={message.user.name === username}
             variant={variant}
+            isLatest={index === allMessages.length - 1}
           />
         ))}
       </div>

--- a/hooks/use-chat-thread.ts
+++ b/hooks/use-chat-thread.ts
@@ -41,8 +41,18 @@ export function useChatThreads() {
       return;
     }
 
+    const recipientIds = [...new Set(conversations.map((c: any) => c.buyer_id === user.id ? c.seller_id : c.buyer_id))];
+    
+    const { data: usersData } = await supabase
+      .from("users")
+      .select("id, first_name, last_name")
+      .in("id", recipientIds);
+      
+    const usersMap = new Map(usersData?.map(u => [u.id, `${u.first_name || ''} ${u.last_name || ''}`.trim() || `User ${u.id.substring(0,8)}`]) || []);
+
     const mapped = conversations.map((c: any) => {
-      const otherId = c.buyer_id === user.id ? c.seller_id : c.buyer_id;
+      const recipientId = c.buyer_id === user.id ? c.seller_id : c.buyer_id;
+      const userName = usersMap.get(recipientId) || `User ${recipientId.substring(0, 8)}`;
       
       const sortedMessages = (c.chat_messages || []).sort(
         (a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
@@ -51,7 +61,7 @@ export function useChatThreads() {
 
       return {
         id: c.id,
-        name: `User ${otherId.substring(0, 8)}`,
+        name: userName,
         lastMessage: lastMsg,
         last_message_at: c.last_message_at,
         time: c.last_message_at


### PR DESCRIPTION
- Display actual usernames in chat sidebar instead of IDs

- Add messenger-style slide-down timestamps on tap/focus

- Add hover tooltips for message timestamps

- Ensure only the latest message displays its timestamp by default
