### PR TITLE
fix(sewist): use shop address for map and location

### DIFF
--- a/app/sewists/[sewistId]/page.tsx
+++ b/app/sewists/[sewistId]/page.tsx
@@ -26,9 +26,11 @@ export default async function SewistPage({ params }: PageProps) {
       first_name,
       last_name,
       email,
+      latitude,
+      longitude,
       user_type,
       user_avatars (avatar_url),
-      user_addresses (province, city, is_primary),
+      user_addresses (province, city, is_primary, address_type, latitude, longitude),
       user_phones (phone),
       sewist_achievements (title),
       sewist_statistics (rating_avg, profile_views_total, total_orders_completed),
@@ -53,14 +55,23 @@ export default async function SewistPage({ params }: PageProps) {
     console.error("View Tracking Error:", err);
   }
 
-  const primaryAddress =
-    user.user_addresses?.find((addr: any) => addr.is_primary) ||
-    user.user_addresses?.[0];
+  const addresses = Array.isArray(user.user_addresses)
+    ? user.user_addresses
+    : [user.user_addresses].filter(Boolean);
+  const shopAddress =
+    addresses.find((addr: any) => addr.address_type === "shop" && addr.is_primary) ||
+    addresses.find((addr: any) => addr.address_type === "shop") ||
+    addresses.find((addr: any) => addr.is_primary) ||
+    addresses[0];
 
   const location =
-    primaryAddress
-      ? `${primaryAddress.city}${primaryAddress.province ? `, ${primaryAddress.province}` : ""}`
+    shopAddress
+      ? `${shopAddress.city}${shopAddress.province ? `, ${shopAddress.province}` : ""}`
       : "Location not set";
+  const mapPosition = {
+    lat: shopAddress?.latitude ?? user.latitude ?? 15.4753,
+    lng: shopAddress?.longitude ?? user.longitude ?? 120.596,
+  };
 
   const avatar = user.user_avatars?.[0]?.avatar_url || "/assets/sewist-photos/1.jpg";
   const name = `${user.first_name || ""} ${user.last_name || ""}`.trim() || "Anonymous Sewist";
@@ -107,9 +118,8 @@ export default async function SewistPage({ params }: PageProps) {
       <AchievementsServices
         achievements={achievements}
         tesdaCertified={tesdaCertified}
-        servicesOffered={servicesOffered as any}
       />
-      <Map />
+      <Map position={mapPosition} />
       <ContactSewist
         sewistName={name}
         mobileNumber={mobileNumber}

--- a/components/sections/sewists/sewists-grid.tsx
+++ b/components/sections/sewists/sewists-grid.tsx
@@ -41,7 +41,7 @@ export default function SewistsGrid({filters, type}: SewistsGridProps) {
             last_name,
             user_type,
             user_avatars (id, avatar_url),
-            user_addresses (province, city, is_primary),
+            user_addresses (province, city, is_primary, address_type),
             sewist_statistics (rating_avg, total_orders_completed),
             sewist_settings (accepting_alterations, accepting_repairs, accepting_commissions),
             sewist_verifications (verification_status),
@@ -69,9 +69,14 @@ export default function SewistsGrid({filters, type}: SewistsGridProps) {
           const verification = user.sewist_verifications?.[0];
           const achievements = user.sewist_achievements || [];
 
+          const addresses = Array.isArray(user.user_addresses)
+            ? user.user_addresses
+            : [user.user_addresses].filter(Boolean);
           const primaryAddress =
-            user.user_addresses?.find((addr: any) => addr.is_primary) ||
-            user.user_addresses?.[0];
+            addresses.find((addr: any) => addr.address_type === "shop" && addr.is_primary) ||
+            addresses.find((addr: any) => addr.address_type === "shop") ||
+            addresses.find((addr: any) => addr.is_primary) ||
+            addresses[0];
 
           const location =
             primaryAddress

--- a/components/sewist-profile/achievements-services.tsx
+++ b/components/sewist-profile/achievements-services.tsx
@@ -3,12 +3,10 @@ import TesdaCertified from "@/components/ui/tesda-certified";
 interface AchievementsServicesProps {
   achievements: string[];
   tesdaCertified: boolean;
-  servicesOffered: ("repair" | "alteration" | "commission")[];
 }
 export default function AchievementsServices({
   achievements,
   tesdaCertified,
-  servicesOffered,
 }: AchievementsServicesProps) {
   return (
     <div className="flex flex-col max-w-dvw h-auto p-12 mx-20">
@@ -22,17 +20,6 @@ export default function AchievementsServices({
       </div>
       <div className="flex flex-row max-w-dvw justify-between py-8">
         {tesdaCertified ? <TesdaCertified /> : null}
-        <div className="flex flex-col ml-20 gap-4 items-end ">
-          <h3 className="text-5xl font-light text-heading-dark">
-            {" "}
-            Services Offered
-          </h3>
-          {servicesOffered.map((service, index) => (
-            <ul key={index} className="text-2xl font-light ">
-              <li>{service}</li>
-            </ul>
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/components/sewist-profile/map.tsx
+++ b/components/sewist-profile/map.tsx
@@ -3,8 +3,11 @@
 import dynamic from "next/dynamic";
 import { useMemo } from "react";
 
-export default function Map() {
-  const position = { lat: 15.4753, lng: 120.596 }; // Tarlac City, Tarlac
+interface SewistMapProps {
+  position?: { lat: number; lng: number };
+}
+
+export default function Map({ position = { lat: 15.4753, lng: 120.596 } }: SewistMapProps) {
 
   const MapComponent = useMemo(
     () =>
@@ -18,7 +21,7 @@ export default function Map() {
   );
 
   return (
-    <div className="h-200 w-max-dvw mx-10">
+    <div className="h-200 w-[70vw] max-w-full mx-auto">
       <MapComponent position={position} />
     </div>
   );


### PR DESCRIPTION
- Prefer shop address for sewist location and map pin so public pages
- show business location instead of shipping or billing data.
- Also remove duplicate Services Offered text block and reduce map width to 70vw for cleaner layout.