### PR TITLE
refactor(commission): normalize request sources

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -70,7 +70,7 @@ WHERE variant_id = 'uuid-123';
 The workflow for custom work.
 - **Service Types:** `commission`, `repair`, `alteration`.
 - **Status:** `pending`, `accepted`, `in_progress`, `completed`, `cancelled`.
-- **Fields:** Includes contact info, `subject` (Required), `request_details`, `appointment_date`, `fabric_id`, `measurement_profile_id`, and `deleted_at` (Timestamp).
+- **Fields:** `client_id`, `sewist_id`, `address_id`, `subject` (Required), `request_details`, `appointment_date`, `fabric` (text value), optional `measurement_profile_id`, and `deleted_at` (Timestamp).
 
 ### Sewist-Specific Config
 - **`sewist_settings`**: Toggles for `accepting_commissions`, `accepting_alterations`, `accepting_repairs`, and `accepting_appointments`.

--- a/DB_SQL.txt
+++ b/DB_SQL.txt
@@ -131,13 +131,11 @@ CREATE TABLE public.service_requests (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   client_id uuid NOT NULL,
   sewist_id uuid NOT NULL,
+  address_id uuid NOT NULL,
   service_type character varying NOT NULL CHECK (service_type::text = ANY (ARRAY['commission'::character varying::text, 'repair'::character varying::text, 'alteration'::character varying::text])),
-  contact_email character varying NOT NULL,
-  contact_phone character varying NOT NULL,
-  contact_name character varying NOT NULL,
   request_details text NOT NULL,
   appointment_date timestamp without time zone NOT NULL,
-  fabric_id uuid,
+  fabric text,
   measurement_profile_id uuid,
   status character varying DEFAULT 'pending'::character varying CHECK (status::text = ANY (ARRAY['pending'::character varying::text, 'accepted'::character varying::text, 'in_progress'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text])),
   created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
@@ -147,6 +145,7 @@ CREATE TABLE public.service_requests (
   CONSTRAINT service_requests_pkey PRIMARY KEY (id),
   CONSTRAINT service_requests_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.users(id),
   CONSTRAINT service_requests_sewist_id_fkey FOREIGN KEY (sewist_id) REFERENCES public.users(id),
+  CONSTRAINT service_requests_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.user_addresses(id),
   CONSTRAINT service_requests_measurement_profile_id_fkey FOREIGN KEY (measurement_profile_id) REFERENCES public.user_measurements(id)
 );
 CREATE TABLE public.sewist_achievements (

--- a/app/sewist-app/(dashboard)/products/page.tsx
+++ b/app/sewist-app/(dashboard)/products/page.tsx
@@ -86,20 +86,54 @@ export default function ProductsPage() {
       // 3. Fetch Service Requests (Commissions & Appointments)
       const { data: requestsData } = await supabase
         .from('service_requests')
-        .select('*')
+        .select(`
+          id,
+          client_id,
+          address_id,
+          service_type,
+          subject,
+          request_details,
+          appointment_date,
+          status,
+          created_at,
+          measurement_profile_id,
+          users!service_requests_client_id_fkey (
+            first_name,
+            last_name,
+            email
+          ),
+          user_addresses!service_requests_address_id_fkey (
+            full_address,
+            barangay,
+            city,
+            province,
+            zip_code,
+            contact_name,
+            contact_phone
+          )
+        `)
         .eq('sewist_id', user.id)
         .is('deleted_at', null) // Only fetch non-archived requests
         .order('created_at', { ascending: false });
 
       if (requestsData) {
-        setAllServiceRequests(requestsData as ServiceRequest[]);
+        const normalizedRequests = requestsData.map((request: any) => {
+          const client = Array.isArray(request.users) ? request.users[0] : request.users;
+          const address = Array.isArray(request.user_addresses) ? request.user_addresses[0] : request.user_addresses;
+          return {
+            ...request,
+            users: client || null,
+            user_addresses: address || null,
+          };
+        });
+        setAllServiceRequests(normalizedRequests as ServiceRequest[]);
         
         // Filter into Commissions (Commissions, Repairs, Alterations)
-        const commissionsList = requestsData
+        const commissionsList = normalizedRequests
           .filter(r => ['commission', 'repair', 'alteration'].includes(r.service_type))
           .map(r => ({
             id: r.id,
-            name: `${r.contact_name} - ${r.subject || r.service_type}`,
+            name: `${`${r.users?.first_name || ""} ${r.users?.last_name || ""}`.trim() || "Customer"} - ${r.subject || r.service_type}`,
             type: r.status
           }));
         setCommissions(commissionsList);

--- a/components/modals/service-request-details-modal.tsx
+++ b/components/modals/service-request-details-modal.tsx
@@ -9,18 +9,27 @@ import { ProfileButton } from "@/components/user-profile/profile-buttons";
 export interface ServiceRequest {
   id: string;
   client_id: string;
+  address_id: string;
   service_type: string;
   subject: string;
   request_details: string;
   appointment_date: string;
   status: "pending" | "accepted" | "in_progress" | "completed" | "cancelled";
   created_at: string;
-  contact_email: string;
-  contact_phone: string;
-  contact_name: string;
+  measurement_profile_id?: string | null;
   users?: {
     first_name: string;
     last_name: string;
+    email?: string;
+  } | null;
+  user_addresses?: {
+    full_address: string;
+    barangay: string;
+    city: string;
+    province: string;
+    zip_code: number;
+    contact_name?: string | null;
+    contact_phone?: string | null;
   };
 }
 
@@ -124,6 +133,15 @@ export const ServiceRequestDetailsModal = ({
     });
   };
 
+  const clientName = request.users
+    ? `${request.users.first_name || ""} ${request.users.last_name || ""}`.trim()
+    : request.user_addresses?.contact_name || "Customer";
+  const clientEmail = request.users?.email || "No email found";
+  const clientPhone = request.user_addresses?.contact_phone || "Not provided";
+  const clientAddress = request.user_addresses
+    ? `${request.user_addresses.full_address}, ${request.user_addresses.barangay}, ${request.user_addresses.city}, ${request.user_addresses.province} ${request.user_addresses.zip_code}`
+    : "No address found";
+
   return (
     <div className="fixed inset-0 z-[1300] flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
@@ -150,14 +168,14 @@ export const ServiceRequestDetailsModal = ({
                 <User className="w-5 h-5 text-third" />
                 <div>
                   <p className="text-xs font-bold text-gray-400 uppercase">Client</p>
-                  <p className="font-semibold text-lg">{request.contact_name}</p>
+                  <p className="font-semibold text-lg">{clientName}</p>
                 </div>
               </div>
               <div className="flex items-center gap-3 text-gray-600">
                 <Mail className="w-5 h-5 text-third" />
                 <div>
                   <p className="text-xs font-bold text-gray-400 uppercase">Email</p>
-                  <p className="font-semibold">{request.contact_email}</p>
+                  <p className="font-semibold">{clientEmail}</p>
                 </div>
               </div>
             </div>
@@ -173,9 +191,16 @@ export const ServiceRequestDetailsModal = ({
                 <Phone className="w-5 h-5 text-third" />
                 <div>
                   <p className="text-xs font-bold text-gray-400 uppercase">Phone</p>
-                  <p className="font-semibold">{request.contact_phone || "Not provided"}</p>
+                  <p className="font-semibold">{clientPhone}</p>
                 </div>
               </div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-100 pt-6">
+            <h3 className="text-sm font-bold text-gray-400 uppercase mb-3">Address</h3>
+            <div className="bg-gray-50 rounded-2xl p-4 text-gray-700 leading-relaxed">
+              {clientAddress}
             </div>
           </div>
 

--- a/components/service/commission-form.tsx
+++ b/components/service/commission-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import Image from "next/image";
+import { useEffect, useState } from "react";
 import PrimaryButton from "../ui/primary-button";
 import { createClient } from "@/utils/supabase/client";
 import { Loader2 } from "lucide-react";
@@ -30,6 +29,41 @@ interface CommissionFormProps {
   orderDetailsLabel?: string;
 }
 
+interface UserAddressOption {
+  id: string;
+  full_address: string;
+  barangay: string;
+  city: string;
+  province: string;
+  zip_code: number;
+  is_primary: boolean;
+  address_type?: string | null;
+}
+
+interface MeasurementOption {
+  id: string;
+  profile_name: string | null;
+  unit: string | null;
+  chest: number | null;
+  shoulder_width: number | null;
+  neck: number | null;
+  sleeve_length_short: number | null;
+  sleeve_length_long: number | null;
+  upper_arm_bicep: number | null;
+  wrist: number | null;
+  shirt_length: number | null;
+  waist_shirt: number | null;
+  waist_pants: number | null;
+  hips: number | null;
+  inseam: number | null;
+  outseam: number | null;
+  thigh: number | null;
+  knee: number | null;
+  leg_opening: number | null;
+  front_rise: number | null;
+  back_rise: number | null;
+}
+
 export default function CommissionForm({
   sewistName,
   sewistImage,
@@ -48,39 +82,74 @@ export default function CommissionForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
+  const [userEmail, setUserEmail] = useState("");
+  const [addresses, setAddresses] = useState<UserAddressOption[]>([]);
+  const [measurementProfiles, setMeasurementProfiles] = useState<MeasurementOption[]>([]);
   const supabase = createClient();
 
   const [formData, setFormData] = useState({
     subject: "",
-    email: "",
-    fullName: "",
+    selectedAddressId: "",
+    selectedMeasurementId: "",
     fabricToUse: "",
     orderDetails: "",
-    measurements: "",
-    scheduleAppointment: "",
     appointmentDate: "",
     images: [] as File[],
   });
 
-  const [showDatePicker, setShowDatePicker] = useState(false);
+  useEffect(() => {
+    const loadUserFormOptions = async () => {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
 
-  const handleScheduleClick = () => {
-    const dateInput = document.getElementById(
-      "appointmentDate"
-    ) as HTMLInputElement;
-    if (dateInput) {
-      dateInput.showPicker();
-    }
-  };
+      if (userError || !user) {
+        setErrorMsg("You must be logged in to submit a request.");
+        return;
+      }
 
-  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedDate = e.target.value;
-    setFormData((prev) => ({
-      ...prev,
-      appointmentDate: selectedDate,
-      scheduleAppointment: selectedDate,
-    }));
-  };
+      setUserEmail(user.email || "");
+
+      const [{ data: addressData, error: addressError }, { data: measurementData, error: measurementError }] =
+        await Promise.all([
+          supabase
+            .from("user_addresses")
+            .select("id, full_address, barangay, city, province, zip_code, is_primary, address_type")
+            .eq("user_id", user.id)
+            .order("is_primary", { ascending: false }),
+          supabase
+            .from("user_measurements")
+            .select("id, profile_name, unit, chest, shoulder_width, neck, sleeve_length_short, sleeve_length_long, upper_arm_bicep, wrist, shirt_length, waist_shirt, waist_pants, hips, inseam, outseam, thigh, knee, leg_opening, front_rise, back_rise")
+            .eq("user_id", user.id)
+            .order("created_at", { ascending: true }),
+        ]);
+
+      if (addressError) {
+        setErrorMsg(addressError.message);
+        return;
+      }
+      if (measurementError) {
+        setErrorMsg(measurementError.message);
+        return;
+      }
+
+      const validAddresses = (addressData || []).filter(
+        (address) => !!address.id && String(address.address_type || "").toLowerCase() !== "shop"
+      );
+      const validMeasurements = (measurementData || []).filter((measurement) => !!measurement.id);
+
+      setAddresses(validAddresses as UserAddressOption[]);
+      setMeasurementProfiles(validMeasurements as MeasurementOption[]);
+      setFormData((prev) => ({
+        ...prev,
+        selectedAddressId: validAddresses[0]?.id || "",
+        selectedMeasurementId: validMeasurements[0]?.id || "",
+      }));
+    };
+
+    loadUserFormOptions();
+  }, [supabase]);
 
   const handleChange = (
     e: React.ChangeEvent<
@@ -89,20 +158,11 @@ export default function CommissionForm({
   ) => {
     const { name, value, type } = e.target;
 
-    if (name === "scheduleAppointment") {
-      setFormData((prev) => ({
-        ...prev,
-        scheduleAppointment: value,
-        appointmentDate: value === "yes" ? prev.appointmentDate : "",
-      }));
-      setShowDatePicker(value === "yes");
-    } else {
-      setFormData((prev) => ({
-        ...prev,
-        [name]:
-          type === "checkbox" ? (e.target as HTMLInputElement).checked : value,
-      }));
-    }
+    setFormData((prev) => ({
+      ...prev,
+      [name]:
+        type === "checkbox" ? (e.target as HTMLInputElement).checked : value,
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -117,13 +177,22 @@ export default function CommissionForm({
         throw new Error("You must be logged in to submit a request.");
       }
 
+      const selectedAddress = addresses.find((address) => address.id === formData.selectedAddressId);
+      const selectedMeasurement = measurementProfiles.find(
+        (measurement) => measurement.id === formData.selectedMeasurementId
+      );
+
+      if (!selectedAddress) {
+        throw new Error("Please add and select an address from your profile first.");
+      }
+      if (!disableMeasurements && !selectedMeasurement) {
+        throw new Error("Please add and select a measurement profile first.");
+      }
+
       // Format details
       let finalDetails = formData.orderDetails;
-      if (formData.fabricToUse) {
-        finalDetails += `\nFabric: ${formData.fabricToUse}`;
-      }
-      if (formData.measurements) {
-        finalDetails += `\nMeasurements: ${formData.measurements}`;
+      if (selectedMeasurement?.profile_name) {
+        finalDetails += `\nMeasurement Preset: ${selectedMeasurement.profile_name}`;
       }
 
       const { error: submitError } = await supabase.from("service_requests").insert({
@@ -131,11 +200,11 @@ export default function CommissionForm({
         sewist_id: sewistId,
         service_type: serviceType,
         subject: formData.subject || `New ${serviceType} request`,
-        contact_email: formData.email || user.email || "",
-        contact_phone: "Not provided", // Add to form later if needed
-        contact_name: formData.fullName || user.user_metadata?.full_name || "User",
+        address_id: selectedAddress.id,
+        fabric: disableFabric ? null : formData.fabricToUse || null,
         request_details: finalDetails,
-        appointment_date: formData.scheduleAppointment === "yes" && formData.appointmentDate 
+        measurement_profile_id: disableMeasurements ? null : selectedMeasurement?.id || null,
+        appointment_date: formData.appointmentDate
           ? new Date(formData.appointmentDate).toISOString()
           : new Date().toISOString(), // Fallback if no date
         status: "pending"
@@ -164,6 +233,32 @@ export default function CommissionForm({
     "Velvet",
     "Other",
   ];
+  const selectedMeasurementProfile = measurementProfiles.find(
+    (measurement) => measurement.id === formData.selectedMeasurementId
+  );
+  const measurementUnit = selectedMeasurementProfile?.unit || "in";
+  const measurementPreviewFields = selectedMeasurementProfile
+    ? [
+        { label: "Chest", value: selectedMeasurementProfile.chest },
+        { label: "Shoulder Width", value: selectedMeasurementProfile.shoulder_width },
+        { label: "Neck", value: selectedMeasurementProfile.neck },
+        { label: "Sleeve (Short)", value: selectedMeasurementProfile.sleeve_length_short },
+        { label: "Sleeve (Long)", value: selectedMeasurementProfile.sleeve_length_long },
+        { label: "Upper Arm/Bicep", value: selectedMeasurementProfile.upper_arm_bicep },
+        { label: "Wrist", value: selectedMeasurementProfile.wrist },
+        { label: "Shirt Length", value: selectedMeasurementProfile.shirt_length },
+        { label: "Waist (Shirt)", value: selectedMeasurementProfile.waist_shirt },
+        { label: "Waist (Pants)", value: selectedMeasurementProfile.waist_pants },
+        { label: "Hips", value: selectedMeasurementProfile.hips },
+        { label: "Inseam", value: selectedMeasurementProfile.inseam },
+        { label: "Outseam", value: selectedMeasurementProfile.outseam },
+        { label: "Thigh", value: selectedMeasurementProfile.thigh },
+        { label: "Knee", value: selectedMeasurementProfile.knee },
+        { label: "Leg Opening", value: selectedMeasurementProfile.leg_opening },
+        { label: "Front Rise", value: selectedMeasurementProfile.front_rise },
+        { label: "Back Rise", value: selectedMeasurementProfile.back_rise },
+      ].filter((field) => field.value !== null)
+    : [];
 
   return (
     <div className="max-w-dvw mx-30 rounded-lg p-10 my-10">
@@ -187,7 +282,7 @@ export default function CommissionForm({
       ) : (
         <form onSubmit={handleSubmit} className="space-y-5">
           {errorMsg && (
-            <div className="p-4 bg-red-50 text-red-500 rounded-md">
+            <div className="p-4 bg-red-50 text-red-500 rounded-2xl">
               {errorMsg}
             </div>
           )}
@@ -207,48 +302,55 @@ export default function CommissionForm({
               placeholder={`E.g. ${serviceType === 'repair' ? 'Fixing a hole' : 'Custom dress inquiry'}`}
               value={formData.subject}
               onChange={handleChange}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent"
+              className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent"
             />
           </div>
         )}
 
         {!disableEmail && (
           <div>
-            <label
-              htmlFor="email"
-              className="block text-base font-light text-black mb-1"
-            >
-              Email <span className="text-red-500">*</span>
+            <label className="block text-base font-light text-black mb-1">
+              Email
             </label>
             <input
               type="email"
-              id="email"
-              name="email"
-              required
-              value={formData.email}
-              onChange={handleChange}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent"
+              value={userEmail}
+              readOnly
+              className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 text-gray-600 focus:outline-none"
             />
           </div>
         )}
 
         {!disableFullName && (
-          <div>
-            <label
-              htmlFor="fullName"
-              className="block text-base font-light text-black mb-1"
-            >
-              Full Name <span className="text-red-500">*</span>
+          <div className="relative">
+            <label className="block text-base font-light text-black mb-1">
+              Address <span className="text-red-500">*</span>
             </label>
-            <input
-              type="text"
-              id="fullName"
-              name="fullName"
-              required
-              value={formData.fullName}
-              onChange={handleChange}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent"
-            />
+            <Select
+              variant="purple"
+              value={formData.selectedAddressId}
+              onValueChange={(val) => setFormData((prev) => ({ ...prev, selectedAddressId: val }))}
+            >
+              <SelectTrigger className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent">
+                <SelectValue placeholder={addresses.length ? "Select your address" : "No saved address found"} />
+              </SelectTrigger>
+              <SelectContent className="rounded-2xl">
+                {addresses.map((address) => (
+                  <SelectItem key={address.id} value={address.id}>
+                    {`${address.full_address}, ${address.city}, ${address.province}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {addresses.length === 0 && (
+              <p className="text-xs text-red-500 mt-1">
+                Add an address in your profile first.
+                {" "}
+                <Link href="/user-profile/addresses" className="underline">
+                  Go to My Addresses
+                </Link>
+              </p>
+            )}
           </div>
         )}
 
@@ -266,10 +368,10 @@ export default function CommissionForm({
               onValueChange={(val) => setFormData(prev => ({ ...prev, fabricToUse: val }))}
               required
             >
-              <SelectTrigger className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent">
+              <SelectTrigger className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent">
                 <SelectValue placeholder="Select fabric type" />
               </SelectTrigger>
-              <SelectContent className="rounded-md">
+              <SelectContent className="rounded-2xl">
                 {fabricOptions.map((fabric) => (
                   <SelectItem key={fabric} value={fabric}>
                     {fabric}
@@ -295,35 +397,66 @@ export default function CommissionForm({
               rows={4}
               value={formData.orderDetails}
               onChange={handleChange}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent resize-none"
+              className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent resize-none"
             />
           </div>
         )}
 
         {!disableMeasurements && (
-          <div>
-            <label
-              htmlFor="measurements"
-              className="block text-base font-light text-black mb-1"
-            >
-              Measurements <span className="text-red-500">*</span>
+          <div className="relative">
+            <label className="block text-base font-light text-black mb-1">
+              Measurement Preset <span className="text-red-500">*</span>
             </label>
-            <textarea
-              id="measurements"
-              name="measurements"
-              required
-              rows={4}
-              value={formData.measurements}
-              onChange={handleChange}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent resize-none"
-            />
+            <Select
+              variant="purple"
+              value={formData.selectedMeasurementId}
+              onValueChange={(val) => setFormData((prev) => ({ ...prev, selectedMeasurementId: val }))}
+            >
+              <SelectTrigger className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent">
+                <SelectValue placeholder={measurementProfiles.length ? "Select measurement profile" : "No measurement profile found"} />
+              </SelectTrigger>
+              <SelectContent className="rounded-2xl">
+                {measurementProfiles.map((measurement) => (
+                  <SelectItem key={measurement.id} value={measurement.id}>
+                    {measurement.profile_name || "Unnamed profile"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {measurementProfiles.length === 0 && (
+              <p className="text-xs text-red-500 mt-1">
+                Add a measurement profile first.
+                {" "}
+                <Link href="/user-profile/measurements" className="underline">
+                  Go to Measurements
+                </Link>
+              </p>
+            )}
+            {selectedMeasurementProfile && (
+              <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-100 p-3">
+                <p className="text-sm font-medium text-heading mb-2">
+                  {selectedMeasurementProfile.profile_name || "Selected profile"} measurements
+                </p>
+                {measurementPreviewFields.length > 0 ? (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-1">
+                    {measurementPreviewFields.map((field) => (
+                      <p key={field.label} className="text-sm text-gray-700">
+                        {field.label}: {field.value} {measurementUnit}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-600">No measurements set in this profile yet.</p>
+                )}
+              </div>
+            )}
           </div>
         )}
 
         {!disableScheduleAppointment && (
           <div>
             <label
-              htmlFor="scheduleAppointment"
+              htmlFor="appointmentDate"
               className="block text-base font-light text-black mb-1"
             >
               Schedule an appointment? <span className="text-red-500">*</span>
@@ -334,9 +467,9 @@ export default function CommissionForm({
               name="appointmentDate"
               required
               value={formData.appointmentDate}
-              onChange={handleDateChange}
+              onChange={handleChange}
               min={new Date().toISOString().split("T")[0]}
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent cursor-pointer"
+              className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent cursor-pointer"
             />
           </div>
         )}
@@ -356,7 +489,7 @@ export default function CommissionForm({
               multiple
               accept="image/*"
               disabled
-              className="w-full px-4 py-2 rounded-md border border-gray-300 bg-gray-200 text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-third file:text-white hover:file:bg-third/90 cursor-not-allowed"
+              className="w-full px-4 py-2 rounded-2xl border border-gray-300 bg-gray-200 text-gray-500 focus:outline-none focus:ring-2 focus:ring-[#2C2463] focus:border-transparent file:mr-4 file:py-2 file:px-4 file:rounded-2xl file:border-0 file:text-sm file:font-semibold file:bg-third file:text-white hover:file:bg-third/90 cursor-not-allowed"
             />
             <p className="text-xs text-gray-500 mt-1">Image uploads are currently being set up. This will be available soon.</p>
           </div>

--- a/components/ui/primary-button.tsx
+++ b/components/ui/primary-button.tsx
@@ -20,7 +20,7 @@ export default function PrimaryButton({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`w-full bg-button-gradient hover:opacity-90 text-white font-semibold py-6 px-6 rounded-2xl transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      className={`w-full bg-button-gradient hover:opacity-90 text-white font-semibold py-6 px-6 rounded-2xl transition-opacity duration-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
     >
       {children}
     </button>


### PR DESCRIPTION
Use profile-backed refs for service requests to avoid duplicated contact and measurement snapshots. Form now submits address_id, measurement_profile_id, and fabric text, while sewist views read client and address via joins.

Refs #82
