### PR TITLE
feat(chat): implement secure private S3 media sharing

### DIFF
--- a/app/api/s3-upload/route.ts
+++ b/app/api/s3-upload/route.ts
@@ -5,15 +5,19 @@ import { s3 } from "@/lib/s3";
 
 export async function POST(request: Request) {
   try {
-    const { filename, contentType, action = "upload" } = await request.json();
+    const { filename, contentType, action = "upload", bucketType = "public" } = await request.json();
 
     if (!filename) {
       return NextResponse.json({ error: "Filename is required" }, { status: 400 });
     }
 
-    const bucket = process.env.NEXT_PUBLIC_AWS_S3_PUBLIC_BUCKET;
+    const publicBucket = process.env.NEXT_PUBLIC_AWS_S3_PUBLIC_BUCKET;
+    const privateBucket = process.env.AWS_S3_PRIVATE_BUCKET;
+    
+    const bucket = bucketType === "private" ? privateBucket : publicBucket;
+
     if (!bucket) {
-      return NextResponse.json({ error: "S3 bucket not configured" }, { status: 500 });
+      return NextResponse.json({ error: `S3 ${bucketType} bucket not configured` }, { status: 500 });
     }
 
     if (action === "upload") {
@@ -26,8 +30,21 @@ export async function POST(request: Request) {
       const signedUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
       return NextResponse.json({ 
         url: signedUrl, 
-        publicUrl: `https://${bucket}.s3.${process.env.AWS_REGION}.amazonaws.com/${filename}`
+        publicUrl: bucketType === "private" 
+          ? `s3-private://${filename}` // Internal marker for private content
+          : `https://${bucket}.s3.${process.env.AWS_REGION}.amazonaws.com/${filename}`
       });
+    }
+
+    if (action === "fetch") {
+      const { GetObjectCommand } = await import("@aws-sdk/client-s3");
+      const command = new GetObjectCommand({
+        Bucket: bucket,
+        Key: filename,
+      });
+
+      const signedUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
+      return NextResponse.json({ url: signedUrl });
     }
 
     if (action === "delete") {

--- a/components/messaging/chat-list-compact.tsx
+++ b/components/messaging/chat-list-compact.tsx
@@ -38,7 +38,9 @@ export function ChatListCompact({ onSelect, selectedId, threads }: ChatListCompa
             </div>
             <div className="flex items-center justify-between gap-2 mt-0.5">
               <p className="text-sm font-medium text-primary/60 truncate leading-tight">
-                {thread.lastMessage}
+                {thread.lastMessage.startsWith("s3-private://") 
+                  ? (/\.(mp4|webm|ogg|mov)$/i.test(thread.lastMessage) ? "Video 🎥" : "Photo 📸")
+                  : thread.lastMessage}
               </p>
               <span className="text-sm font-bold text-primary/40 shrink-0">
                 {thread.time}

--- a/components/messaging/chat-message.tsx
+++ b/components/messaging/chat-message.tsx
@@ -1,5 +1,10 @@
+"use client";
+
 import { cn } from '@/lib/utils'
+import { Maximize2 } from 'lucide-react'
 import type { ChatMessage } from '@/hooks/use-realtime-chat'
+import PrivateVideoPlayer from './private-video-player'
+import PrivateImage from './private-image'
 
 interface ChatMessageItemProps {
   message: ChatMessage
@@ -7,18 +12,28 @@ interface ChatMessageItemProps {
   showHeader?: boolean
   variant?: "default" | "compact"
   isLatest?: boolean
+  onPreview?: (url: string, type: "image" | "video") => void
 }
 
-export const ChatMessageItem = ({ message, isOwnMessage, variant = "default", isLatest = false }: ChatMessageItemProps) => {
+export const ChatMessageItem = ({ message, isOwnMessage, variant = "default", isLatest = false, onPreview }: ChatMessageItemProps) => {
   const isCompact = variant === "compact";
   
   const timeString = message.createdAt 
     ? new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     : '';
 
+  const isVideo = /\.(mp4|webm|ogg|mov)$/i.test(message.content);
+  const isImage = /\.(jpg|jpeg|png|webp|gif|svg)$/i.test(message.content);
+  const isPrivate = message.content.startsWith("s3-private://");
+  const isMedia = isVideo || isImage || isPrivate;
+
   return (
     <div 
-      className={`flex w-full flex-col ${isOwnMessage ? 'items-end' : 'items-start'} ${isCompact ? 'mb-2' : 'mb-4'} group focus:outline-none`} 
+      className={cn(
+        "flex w-full flex-col group focus:outline-none",
+        isOwnMessage ? 'items-end' : 'items-start',
+        isCompact ? 'mb-2' : 'mb-4'
+      )}
       tabIndex={0}
     >
       <div className="relative flex max-w-[80%] items-center group/tooltip">
@@ -31,12 +46,31 @@ export const ChatMessageItem = ({ message, isOwnMessage, variant = "default", is
 
         <div
           className={cn(
-            'shadow-sm text-white font-medium transition-transform active:scale-[0.98] w-full whitespace-pre-wrap break-words',
-            isCompact ? 'px-4 py-2 rounded-2xl text-sm bg-primary' : 'px-8 py-4 rounded-3xl text-lg third-gradient',
-            isOwnMessage ? (isCompact ? 'rounded-tr-none' : 'rounded-tr-none') : (isCompact ? 'rounded-tl-none' : 'rounded-tl-none')
+            'shadow-sm font-medium transition-transform active:scale-[0.98] w-full',
+            isMedia ? 'p-1 rounded-3xl bg-secondary/10 border-2 border-primary/5' : (
+              isCompact ? 'px-4 py-2 rounded-2xl text-sm bg-primary text-white whitespace-pre-wrap break-words' : 'px-8 py-4 rounded-3xl text-lg third-gradient text-white whitespace-pre-wrap break-words'
+            ),
+            isOwnMessage ? 'rounded-tr-none' : 'rounded-tl-none'
           )}
         >
-          {message.content}
+          {isMedia ? (
+            <div 
+              onClick={() => onPreview?.(message.content, (isVideo || (isPrivate && !isImage)) ? "video" : "image")}
+              className="cursor-pointer group/media relative"
+            >
+              {(isVideo || (isPrivate && !isImage)) 
+                ? <PrivateVideoPlayer url={message.content} className="w-full max-w-[320px] sm:max-w-[400px]" />
+                : <PrivateImage url={message.content} className="w-full max-w-[320px] sm:max-w-[400px]" />
+              }
+              <div className="absolute inset-0 bg-black/0 group-hover/media:bg-black/10 transition-colors rounded-2xl flex items-center justify-center opacity-0 group-hover/media:opacity-100">
+                  <div className="bg-black/40 p-2 rounded-full backdrop-blur-sm">
+                    <Maximize2 className="text-white h-5 w-5" />
+                  </div>
+              </div>
+            </div>
+          ) : (
+            message.content
+          )}
         </div>
 
         {/* Tooltip for other message (appears on the right) */}

--- a/components/messaging/chat-thread-item.tsx
+++ b/components/messaging/chat-thread-item.tsx
@@ -39,7 +39,9 @@ export const ChatThreadItem = ({ thread, isSelected, onSelect }: ChatThreadItemP
           </span>
         </div>
         <p className="text-sm font-medium text-primary/60 truncate -mt-1">
-          {thread.lastMessage}
+          {thread.lastMessage.startsWith("s3-private://") 
+            ? (/\.(mp4|webm|ogg|mov)$/i.test(thread.lastMessage) ? "Video 🎥" : "Photo 📸")
+            : thread.lastMessage}
         </p>
       </div>
     </div>

--- a/components/messaging/media-preview-modal.tsx
+++ b/components/messaging/media-preview-modal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { X, Download, Maximize2, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MediaPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  url: string | null;
+  type: "image" | "video";
+}
+
+export default function MediaPreviewModal({ isOpen, onClose, url, type }: MediaPreviewModalProps) {
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !url) return;
+
+    async function fetchSignedUrl() {
+      if (!url?.startsWith("s3-private://")) {
+        setSignedUrl(url);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const filename = url.replace("s3-private://", "").replace(/^\/+/, "");
+        
+        const res = await fetch("/api/s3-upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ 
+            filename, 
+            action: "fetch", 
+            bucketType: "private" 
+          }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || "Failed to get signed URL");
+        setSignedUrl(data.url);
+      } catch (err: any) {
+        console.error("Preview fetch error:", err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSignedUrl();
+  }, [isOpen, url]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex flex-col bg-black/95 backdrop-blur-md animate-in fade-in duration-300">
+      {/* Header */}
+      <div className="flex items-center justify-end p-6 text-white z-20 bg-linear-to-b from-black/60 to-transparent">
+        <div className="flex items-center gap-4">
+          {signedUrl && (
+            <a 
+              href={signedUrl} 
+              download 
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-3 hover:bg-white/10 rounded-full transition-colors"
+            >
+              <Download className="h-6 w-6" />
+            </a>
+          )}
+          <button 
+            onClick={onClose}
+            className="p-3 hover:bg-rose-500 rounded-full transition-all active:scale-95"
+          >
+            <X className="h-8 w-8" />
+          </button>
+        </div>
+      </div>
+
+      {/* Main Content Area */}
+      <div className="flex-1 relative flex items-center justify-center p-4 sm:p-12 overflow-hidden">
+        {loading && (
+          <div className="flex flex-col items-center gap-4">
+             <Loader2 className="h-12 w-12 animate-spin text-primary" />
+             <p className="text-white/40 font-medium">Securing content...</p>
+          </div>
+        )}
+
+        {error && (
+          <div className="text-center space-y-4">
+             <div className="bg-rose-500/20 p-6 rounded-full inline-block">
+                <X className="h-12 w-12 text-rose-500" />
+             </div>
+             <p className="text-rose-500 text-lg font-bold">{error}</p>
+             <button onClick={onClose} className="text-white/60 underline">Go back</button>
+          </div>
+        )}
+
+        {!loading && !error && signedUrl && (
+          <div className="w-full h-full flex items-center justify-center animate-in zoom-in-95 duration-300">
+            {type === "image" ? (
+              <img 
+                src={signedUrl} 
+                alt="Full size preview"
+                className="max-w-full max-h-full object-contain rounded-lg shadow-2xl shadow-black"
+              />
+            ) : (
+              <video 
+                src={signedUrl} 
+                controls 
+                autoPlay
+                className="max-w-full max-h-full rounded-lg shadow-2xl shadow-black"
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/messaging/private-image.tsx
+++ b/components/messaging/private-image.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import Image from "next/image";
+import { Loader2, ImageIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PrivateImageProps {
+  url: string;
+  alt?: string;
+  className?: string;
+}
+
+export default function PrivateImage({ url, alt = "Shared image", className }: PrivateImageProps) {
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSignedUrl() {
+      if (!url.startsWith("s3-private://")) {
+        setSignedUrl(url);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const filename = url.replace("s3-private://", "").replace(/^\/+/, "");
+        
+        const res = await fetch("/api/s3-upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ 
+            filename, 
+            action: "fetch", 
+            bucketType: "private" 
+          }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || "Failed to get signed URL");
+        setSignedUrl(data.url);
+      } catch (err: any) {
+        console.error("Image fetch error:", err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSignedUrl();
+  }, [url]);
+
+  const showLoading = loading || (signedUrl && !imageLoaded);
+
+  if (error) {
+    return (
+      <div className="flex h-48 w-full max-w-[320px] items-center justify-center bg-rose-50 border-2 border-rose-100 rounded-2xl p-4 text-center text-rose-500">
+        <ImageIcon className="h-8 w-8 mb-2 opacity-20" />
+        <p className="text-xs font-medium text-rose-500">Failed to load image</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative w-full max-w-[400px] rounded-2xl overflow-hidden bg-gray-50 shadow-sm border border-black/5 min-h-[100px]", className)}>
+      {showLoading && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-100 animate-pulse">
+          <Loader2 className="h-6 w-6 animate-spin text-primary/40" />
+        </div>
+      )}
+      
+      {signedUrl && (
+        <img 
+          src={signedUrl} 
+          alt={alt}
+          onLoad={() => setImageLoaded(true)}
+          className={cn(
+            "w-full h-auto object-contain transition-opacity duration-300",
+            imageLoaded ? "opacity-100" : "opacity-0"
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/messaging/private-video-player.tsx
+++ b/components/messaging/private-video-player.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Loader2, PlayCircle } from "lucide-react";
+
+interface PrivateVideoPlayerProps {
+  url: string;
+  className?: string;
+}
+
+export default function PrivateVideoPlayer({ url, className }: PrivateVideoPlayerProps) {
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchSignedUrl() {
+      // Check if it's a private S3 marker
+      if (!url.startsWith("s3-private://")) {
+        setSignedUrl(url);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const filename = url.replace("s3-private://", "").replace(/^\/+/, "");
+        
+        const res = await fetch("/api/s3-upload", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ 
+            filename, 
+            action: "fetch", 
+            bucketType: "private" 
+          }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.error || "Failed to get signed URL");
+        }
+
+        setSignedUrl(data.url);
+      } catch (err: any) {
+        console.error("Video fetch error:", err);
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSignedUrl();
+  }, [url]);
+
+  if (loading) {
+    return (
+      <div className="flex h-48 w-full items-center justify-center bg-gray-100 rounded-2xl animate-pulse">
+        <Loader2 className="h-8 w-8 animate-spin text-primary/40" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-48 w-full items-center justify-center bg-rose-50 border-2 border-rose-100 rounded-2xl p-4 text-center">
+        <p className="text-sm text-rose-500 font-medium">Failed to load video</p>
+      </div>
+    );
+  }
+
+  if (!signedUrl) return null;
+
+  return (
+    <div className={className}>
+      <video 
+        src={signedUrl} 
+        controls 
+        className="w-full rounded-2xl shadow-sm border border-black/5 bg-black"
+        preload="metadata"
+      >
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+}

--- a/components/messaging/realtime-chat.tsx
+++ b/components/messaging/realtime-chat.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { SendHorizontal, Smile, Image as ImageIcon, Play, FileText, Mail, Copy } from 'lucide-react'
+import { SendHorizontal, Smile, Image as ImageIcon, Play, FileText, Mail, Copy, Loader2 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 
 import { cn } from '@/lib/utils'
 import { ChatMessageItem } from './chat-message'
 import { useChatScroll } from '@/hooks/use-chat-scroll'
+import MediaPreviewModal from './media-preview-modal'
 import {
   useRealtimeChat,
   type ChatMessage,
@@ -43,7 +44,12 @@ export const RealtimeChat = ({
     username,
   })
   const textareaRef = useRef<HTMLTextAreaElement>(null);  
+  const mediaInputRef = useRef<HTMLInputElement>(null);
   const [newMessage, setNewMessage] = useState('')
+  const [isUploading, setIsUploading] = useState(false)
+  const [stagedMedia, setStagedMedia] = useState<{ file: File; preview: string; type: 'image' | 'video' } | null>(null)
+
+  const [previewData, setPreviewData] = useState<{ url: string; type: 'image' | 'video' } | null>(null)
 
   const allMessages = useMemo(() => {
     const mergedMessages = [...initialMessages, ...realtimeMessages]
@@ -77,6 +83,93 @@ export const RealtimeChat = ({
     },
     [newMessage, isConnected, sendMessage]
   )
+
+  const handleMediaSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !isConnected) return;
+
+    const isVideo = file.type.startsWith('video/');
+    const isImage = file.type.startsWith('image/');
+
+    if (!isVideo && !isImage) {
+      alert('Only image and video files are allowed.');
+      return;
+    }
+
+    // Size limits: 5MB for images, 25MB for videos
+    const sizeLimit = isImage ? 5 * 1024 * 1024 : 25 * 1024 * 1024;
+    if (file.size > sizeLimit) {
+      alert(`File is too large. Maximum size for ${isImage ? 'images' : 'videos'} is ${isImage ? '5MB' : '25MB'}.`);
+      return;
+    }
+
+    // Secondary extension check
+    const allowedExtensions = isImage 
+      ? ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg'] 
+      : ['mp4', 'webm', 'ogg', 'mov'];
+    const fileExt = file.name.split('.').pop()?.toLowerCase();
+    
+    if (!fileExt || !allowedExtensions.includes(fileExt)) {
+      alert(`Unsupported file extension: .${fileExt}. Allowed: ${allowedExtensions.join(', ')}`);
+      return;
+    }
+
+    // Create local preview
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setStagedMedia({
+        file,
+        preview: reader.result as string,
+        type: isImage ? 'image' : 'video'
+      });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleSendStagedMedia = async () => {
+    if (!stagedMedia || !isConnected) return;
+
+    try {
+      setIsUploading(true);
+      const { file, type } = stagedMedia;
+      const fileExt = file.name.split('.').pop();
+      const folder = type === 'video' ? 'chat-videos' : 'chat-images';
+      const fileName = `${folder}/${roomName}/${Date.now()}.${fileExt}`;
+
+      // 1. Get signed upload URL for private bucket
+      const res = await fetch('/api/s3-upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ 
+          filename: fileName, 
+          contentType: file.type,
+          bucketType: 'private'
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to get upload URL');
+      const { url, publicUrl } = await res.json();
+
+      // 2. Upload to S3
+      const uploadRes = await fetch(url, {
+        method: 'PUT',
+        body: file,
+        headers: { 'Content-Type': file.type },
+      });
+
+      if (!uploadRes.ok) throw new Error(`Failed to upload media`);
+
+      // 3. Send message with the private URL marker
+      sendMessage(publicUrl);
+      setStagedMedia(null);
+    } catch (err: any) {
+      console.error('Media upload error:', err);
+      alert('Failed to upload media: ' + err.message);
+    } finally {
+      setIsUploading(false);
+      if (mediaInputRef.current) mediaInputRef.current.value = '';
+    }
+  };
 
   return (
     <div className="flex flex-col h-full w-full bg-background antialiased">
@@ -112,15 +205,65 @@ export const RealtimeChat = ({
             isOwnMessage={message.user.name === username}
             variant={variant}
             isLatest={index === allMessages.length - 1}
+            onPreview={(url, type) => setPreviewData({ url, type })}
           />
         ))}
+
+        {isUploading && (
+          <div className="flex justify-end mb-4 animate-pulse px-12">
+             <div className="px-6 py-3 rounded-3xl bg-secondary/20 border border-primary/10 text-primary/40 text-sm flex items-center gap-2 font-medium">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Uploading media...
+             </div>
+          </div>
+        )}
       </div>
 
+      {/* Media Preview Overlay */}
+      {stagedMedia && (
+        <div className="px-8 pb-4 animate-in slide-in-from-bottom-4 duration-300">
+           <div className="relative group bg-secondary/10 rounded-3xl p-4 border-2 border-primary/5 flex items-center gap-6 shadow-sm overflow-hidden">
+              <div className="relative h-32 w-32 shrink-0 rounded-2xl overflow-hidden bg-black shadow-md border border-white/20">
+                {stagedMedia.type === 'image' ? (
+                  <img src={stagedMedia.preview} alt="Preview" className="w-full h-full object-cover" />
+                ) : (
+                  <video src={stagedMedia.preview} className="w-full h-full object-cover" />
+                )}
+                <div className="absolute inset-0 bg-black/20 flex items-center justify-center pointer-events-none">
+                  {stagedMedia.type === 'video' && <Play className="text-white h-8 w-8 fill-current" />}
+                </div>
+              </div>
+              
+              <div className="flex-1 space-y-1 overflow-hidden">
+                <p className="font-bold text-primary truncate">{stagedMedia.file.name}</p>
+                <p className="text-sm text-primary/40">{(stagedMedia.file.size / (1024 * 1024)).toFixed(2)} MB</p>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <button 
+                  onClick={handleSendStagedMedia}
+                  disabled={isUploading}
+                  className="bg-primary text-white px-6 py-2 rounded-xl font-bold hover:opacity-90 active:scale-95 transition-all disabled:opacity-50 min-w-[100px]"
+                >
+                  {isUploading ? <Loader2 className="h-5 w-5 animate-spin mx-auto" /> : "Send"}
+                </button>
+                <button 
+                  onClick={() => setStagedMedia(null)}
+                  disabled={isUploading}
+                  className="text-primary/40 hover:text-rose-500 font-bold px-4 py-2 transition-colors text-sm"
+                >
+                  Cancel
+                </button>
+              </div>
+           </div>
+        </div>
+      )}
+
       {/* Input Area */}
-      <div className={cn(!isCompact ? "p-8 space-y-4" : "p-4 space-y-2")}>
+      <div className={cn(!isCompact ? "p-8 pt-0 space-y-4" : "p-4 pt-0 space-y-2")}>
         <form 
           onSubmit={handleSendMessage} 
-          className="relative group"
+          className={cn("relative group transition-opacity", stagedMedia ? "opacity-50 pointer-events-none grayscale" : "opacity-100")}
         >
           <textarea
             ref={textareaRef}
@@ -150,12 +293,12 @@ export const RealtimeChat = ({
                 handleSendMessage(e as any);
               }
             }}
-            placeholder="Type your message here"
-            disabled={!isConnected}
+            placeholder={stagedMedia ? "Media ready to send" : "Type your message here"}
+            disabled={!isConnected || !!stagedMedia}
           />
           <button
             type="submit"
-            disabled={!isConnected || !newMessage.trim()}
+            disabled={!isConnected || !newMessage.trim() || isUploading || !!stagedMedia}
             className="absolute right-4 top-1/2 -translate-y-1/2 text-third hover:scale-110 active:scale-95 transition-all disabled:opacity-30 disabled:hover:scale-100"
           >
 
@@ -165,13 +308,37 @@ export const RealtimeChat = ({
 
         {/* Action Icons */}
         <div className={cn("flex gap-4", isCompact ? "px-1" : "px-2 pl-4")}>
-          {[Smile, ImageIcon, Play, FileText, Mail, Copy].map((Icon, idx) => (
-            <button key={idx} className="text-primary/40 hover:text-third transition-colors">
+          <input
+            type="file"
+            ref={mediaInputRef}
+            onChange={handleMediaSelect}
+            accept="image/*,video/*"
+            className="hidden"
+          />
+          {[
+            { Icon: Smile },
+            { Icon: ImageIcon, onClick: () => mediaInputRef.current?.click() },
+            { Icon: Copy }
+          ].map(({ Icon, onClick }, idx) => (
+            <button 
+              key={idx} 
+              type="button"
+              onClick={onClick}
+              disabled={isUploading || !!stagedMedia}
+              className="text-primary/40 hover:text-third transition-colors disabled:opacity-50"
+            >
               <Icon className={cn(isCompact ? "size-4" : "size-5")} />
             </button>
           ))}
         </div>
       </div>
+
+      <MediaPreviewModal
+        isOpen={!!previewData}
+        url={previewData?.url || null}
+        type={previewData?.type || 'image'}
+        onClose={() => setPreviewData(null)}
+      />
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1036.0",
         "@aws-sdk/s3-request-presigner": "^3.1036.0",
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
@@ -1379,6 +1381,36 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+      "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ffmpeg/types": "^0.12.4"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/@ffmpeg/types": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+      "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/util": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1036.0",
     "@aws-sdk/s3-request-presigner": "^3.1036.0",
+    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",


### PR DESCRIPTION
- Implement private S3 bucket support with signed URL fetching
- Add staged media previews (image/video) before sending
- Create PrivateImage and PrivateVideoPlayer components
- Add full-screen Messenger-style MediaPreviewModal
- Consolidate media upload UI and add 25MB video/5MB image limits
- Fix chat list snippets to show friendly media labels

Closes #87
